### PR TITLE
fcm tokenの取得と更新の実装

### DIFF
--- a/Understand Me.xcodeproj/project.pbxproj
+++ b/Understand Me.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		7FBAD4C42E9888B3006807B8 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 7FBAD4C32E9888B3006807B8 /* FirebaseAuth */; };
+		7FBAD4C52E9888B3006807B8 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 7FBAD4C62E9888B3006807B8 /* FirebaseMessaging */; };
 		7FBAD62B2E988DEA006807B8 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 7FBAD62A2E988DEA006807B8 /* GoogleSignIn */; };
 		7FBAD62D2E988E46006807B8 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7FBAD62C2E988E46006807B8 /* GoogleSignInSwift */; };
 		7FC8C3272E95375400B4CF5D /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 7FC8C3262E95375400B4CF5D /* Lottie */; };
@@ -32,6 +33,7 @@
 			files = (
 				7FC8C3272E95375400B4CF5D /* Lottie in Frameworks */,
 				7FBAD4C42E9888B3006807B8 /* FirebaseAuth in Frameworks */,
+				7FBAD4C52E9888B3006807B8 /* FirebaseMessaging in Frameworks */,
 				7FBAD62B2E988DEA006807B8 /* GoogleSignIn in Frameworks */,
 				7FBAD62D2E988E46006807B8 /* GoogleSignInSwift in Frameworks */,
 			);
@@ -78,6 +80,7 @@
 			packageProductDependencies = (
 				7FC8C3262E95375400B4CF5D /* Lottie */,
 				7FBAD4C32E9888B3006807B8 /* FirebaseAuth */,
+				7FBAD4C62E9888B3006807B8 /* FirebaseMessaging */,
 				7FBAD62A2E988DEA006807B8 /* GoogleSignIn */,
 				7FBAD62C2E988E46006807B8 /* GoogleSignInSwift */,
 			);
@@ -389,6 +392,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 7FBAD4C22E9888B3006807B8 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAuth;
+		};
+		7FBAD4C62E9888B3006807B8 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7FBAD4C22E9888B3006807B8 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
 		};
 		7FBAD62A2E988DEA006807B8 /* GoogleSignIn */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Understand Me/Helper/FCMTokenManager.swift
+++ b/Understand Me/Helper/FCMTokenManager.swift
@@ -1,0 +1,52 @@
+//
+//  FCMTokenManager.swift
+//  Understand Me
+//
+//  Created by GitHub Copilot on 2025/10/28.
+//
+
+import Foundation
+import FirebaseMessaging
+
+class FCMTokenManager {
+    static let shared = FCMTokenManager()
+    
+    private init() {}
+    
+    /// Get the current FCM token
+    func getFCMToken() async throws -> String {
+        return try await withCheckedThrowingContinuation { continuation in
+            Messaging.messaging().token { token, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let token = token {
+                    continuation.resume(returning: token)
+                } else {
+                    continuation.resume(throwing: FCMTokenError.tokenNotAvailable)
+                }
+            }
+        }
+    }
+    
+    /// Update FCM token to the server
+    func updateFCMTokenToServer(userID: String, userDataUseCase: UserDataUseCase) async {
+        do {
+            let token = try await getFCMToken()
+            try await userDataUseCase.updateFCMToken(userID: userID, fcmToken: token)
+            print("FCMトークンが正常に更新されました: \(token)")
+        } catch {
+            print("FCMトークンの更新に失敗しました: \(error.localizedDescription)")
+        }
+    }
+}
+
+enum FCMTokenError: Error {
+    case tokenNotAvailable
+    
+    var localizedDescription: String {
+        switch self {
+        case .tokenNotAvailable:
+            return "FCMトークンが取得できませんでした"
+        }
+    }
+}

--- a/Understand Me/Helper/FCMTokenManager.swift
+++ b/Understand Me/Helper/FCMTokenManager.swift
@@ -8,6 +8,10 @@
 import Foundation
 import FirebaseMessaging
 
+extension Notification.Name {
+    static let fcmTokenRefreshed = Notification.Name("FCMTokenRefreshed")
+}
+
 class FCMTokenManager {
     static let shared = FCMTokenManager()
     
@@ -33,9 +37,9 @@ class FCMTokenManager {
         do {
             let token = try await getFCMToken()
             try await userDataUseCase.updateFCMToken(userID: userID, fcmToken: token)
-            print("FCMトークンが正常に更新されました: \(token)")
+            NSLog("FCMトークンが正常に更新されました: %@", token)
         } catch {
-            print("FCMトークンの更新に失敗しました: \(error.localizedDescription)")
+            NSLog("FCMトークンの更新に失敗しました: %@", error.localizedDescription)
         }
     }
 }

--- a/Understand Me/Helper/FCMTokenManager.swift
+++ b/Understand Me/Helper/FCMTokenManager.swift
@@ -17,7 +17,7 @@ class FCMTokenManager {
     
     private init() {}
     
-    /// Get the current FCM token
+    /// 新しいFCMトークンを非同期に取得する
     func getFCMToken() async throws -> String {
         return try await withCheckedThrowingContinuation { continuation in
             Messaging.messaging().token { token, error in
@@ -32,14 +32,14 @@ class FCMTokenManager {
         }
     }
     
-    /// Update FCM token to the server
+    /// FCMトークンをサーバーに更新する
     func updateFCMTokenToServer(userID: String, userDataUseCase: UserDataUseCase) async {
         do {
             let token = try await getFCMToken()
             try await userDataUseCase.updateFCMToken(userID: userID, fcmToken: token)
-            NSLog("FCMトークンが正常に更新されました: %@", token)
+            print("FCMトークンが正常に更新されました: \(token)")
         } catch {
-            NSLog("FCMトークンの更新に失敗しました: %@", error.localizedDescription)
+            print("FCMトークンの更新に失敗しました: \(error.localizedDescription)")
         }
     }
 }

--- a/Understand Me/Presentation/Understand_MeApp.swift
+++ b/Understand Me/Presentation/Understand_MeApp.swift
@@ -15,10 +15,10 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         FirebaseApp.configure()
         
-        // Set up Firebase Messaging delegate
+        // Firebase Cloud Messagingのデリゲートを設定
         Messaging.messaging().delegate = self
         
-        // Request notification permissions
+        // 通知の許可をリクエスト
         UNUserNotificationCenter.current().delegate = self
         
         let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
@@ -26,19 +26,21 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             options: authOptions,
             completionHandler: { granted, error in
                 if let error = error {
-                    NSLog("通知許可の取得に失敗しました: %@", error.localizedDescription)
+                    print("通知許可の取得に失敗しました: %@", error.localizedDescription)
                 } else if granted {
-                    NSLog("通知許可が付与されました")
+                    print("通知許可が付与されました")
                 }
             }
         )
         
+        // Apple Push Notificationサービスに登録
         application.registerForRemoteNotifications()
         
         return true
     }
     
-    func application(_ application: UIApplication, 
+    // Apple Push Notificationサービスへの登録が成功した場合に呼ばれる
+    func application(_ application: UIApplication,
                      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         Messaging.messaging().apnsToken = deviceToken
     }
@@ -46,15 +48,16 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
 // MARK: - MessagingDelegate
 extension AppDelegate: MessagingDelegate {
+    // FCMトークンが更新されたときに呼ばれる
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         guard let fcmToken = fcmToken else {
-            NSLog("FCMトークンがnilです")
+            print("FCMトークンがnilです")
             return
         }
         
-        NSLog("FCMトークンを受信しました: %@", fcmToken)
+        print("FCMトークンを受信しました: %@", fcmToken)
         
-        // Post notification when token is refreshed
+        // FCM トークンが更新されたことを通知(アプリ内通知)
         NotificationCenter.default.post(
             name: .fcmTokenRefreshed,
             object: nil,

--- a/Understand Me/Presentation/Understand_MeApp.swift
+++ b/Understand Me/Presentation/Understand_MeApp.swift
@@ -7,13 +7,74 @@
 
 import SwiftUI
 import Firebase
+import FirebaseMessaging
+import UserNotifications
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         FirebaseApp.configure()
         
+        // Set up Firebase Messaging delegate
+        Messaging.messaging().delegate = self
+        
+        // Request notification permissions
+        UNUserNotificationCenter.current().delegate = self
+        
+        let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+        UNUserNotificationCenter.current().requestAuthorization(
+            options: authOptions,
+            completionHandler: { granted, error in
+                if let error = error {
+                    print("通知許可の取得に失敗しました: \(error.localizedDescription)")
+                } else if granted {
+                    print("通知許可が付与されました")
+                }
+            }
+        )
+        
+        application.registerForRemoteNotifications()
+        
         return true
+    }
+    
+    func application(_ application: UIApplication, 
+                     didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        Messaging.messaging().apnsToken = deviceToken
+    }
+}
+
+// MARK: - MessagingDelegate
+extension AppDelegate: MessagingDelegate {
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        guard let fcmToken = fcmToken else {
+            print("FCMトークンがnilです")
+            return
+        }
+        
+        print("FCMトークンを受信しました: \(fcmToken)")
+        
+        // Post notification when token is refreshed
+        NotificationCenter.default.post(
+            name: Notification.Name("FCMTokenRefreshed"),
+            object: nil,
+            userInfo: ["token": fcmToken]
+        )
+    }
+}
+
+// MARK: - UNUserNotificationCenterDelegate
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([[.banner, .sound]])
+    }
+    
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+        completionHandler()
     }
 }
 

--- a/Understand Me/Presentation/Understand_MeApp.swift
+++ b/Understand Me/Presentation/Understand_MeApp.swift
@@ -26,9 +26,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             options: authOptions,
             completionHandler: { granted, error in
                 if let error = error {
-                    print("通知許可の取得に失敗しました: \(error.localizedDescription)")
+                    NSLog("通知許可の取得に失敗しました: %@", error.localizedDescription)
                 } else if granted {
-                    print("通知許可が付与されました")
+                    NSLog("通知許可が付与されました")
                 }
             }
         )
@@ -48,15 +48,15 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 extension AppDelegate: MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         guard let fcmToken = fcmToken else {
-            print("FCMトークンがnilです")
+            NSLog("FCMトークンがnilです")
             return
         }
         
-        print("FCMトークンを受信しました: \(fcmToken)")
+        NSLog("FCMトークンを受信しました: %@", fcmToken)
         
         // Post notification when token is refreshed
         NotificationCenter.default.post(
-            name: Notification.Name("FCMTokenRefreshed"),
+            name: .fcmTokenRefreshed,
             object: nil,
             userInfo: ["token": fcmToken]
         )

--- a/Understand Me/Presentation/ViewModels/MainTabViewModel.swift
+++ b/Understand Me/Presentation/ViewModels/MainTabViewModel.swift
@@ -24,6 +24,7 @@ class MainTabViewModel: ObservableObject {
         }
     }
     
+    // App DelegateでFCMトークンが更新されたときに呼ばれる通知を監視する
     private func setupFCMTokenObserver() {
         fcmTokenObserver = NotificationCenter.default.addObserver(
             forName: .fcmTokenRefreshed,
@@ -80,7 +81,7 @@ class MainTabViewModel: ObservableObject {
         do {
             self.userData = try await userDataUseCase.fetchUserData(userID: userID)
             
-            // Update FCM token after user data is loaded
+            // FCMトークンをサーバーに送信
             await FCMTokenManager.shared.updateFCMTokenToServer(
                 userID: userID,
                 userDataUseCase: userDataUseCase

--- a/Understand Me/Presentation/ViewModels/MainTabViewModel.swift
+++ b/Understand Me/Presentation/ViewModels/MainTabViewModel.swift
@@ -26,7 +26,7 @@ class MainTabViewModel: ObservableObject {
     
     private func setupFCMTokenObserver() {
         fcmTokenObserver = NotificationCenter.default.addObserver(
-            forName: Notification.Name("FCMTokenRefreshed"),
+            forName: .fcmTokenRefreshed,
             object: nil,
             queue: .main
         ) { [weak self] notification in

--- a/Understand Me/Presentation/ViewModels/MainTabViewModel.swift
+++ b/Understand Me/Presentation/ViewModels/MainTabViewModel.swift
@@ -11,9 +11,35 @@ import Combine
 class MainTabViewModel: ObservableObject {
     @Published var userData: UserData? = nil
     private let userDataUseCase: UserDataUseCase
+    private var fcmTokenObserver: NSObjectProtocol?
     
     init(userDataUseCase: UserDataUseCase) {
         self.userDataUseCase = userDataUseCase
+        setupFCMTokenObserver()
+    }
+    
+    deinit {
+        if let observer = fcmTokenObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+    
+    private func setupFCMTokenObserver() {
+        fcmTokenObserver = NotificationCenter.default.addObserver(
+            forName: Notification.Name("FCMTokenRefreshed"),
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self = self,
+                  let userID = self.userData?.id else { return }
+            
+            Task {
+                await FCMTokenManager.shared.updateFCMTokenToServer(
+                    userID: userID,
+                    userDataUseCase: self.userDataUseCase
+                )
+            }
+        }
     }
     
     
@@ -53,6 +79,12 @@ class MainTabViewModel: ObservableObject {
     func loadUserData(userID: String) async {
         do {
             self.userData = try await userDataUseCase.fetchUserData(userID: userID)
+            
+            // Update FCM token after user data is loaded
+            await FCMTokenManager.shared.updateFCMTokenToServer(
+                userID: userID,
+                userDataUseCase: userDataUseCase
+            )
         } catch {
             // TODO: Userにエラーを知らせる
             print("MainTabViewModel.loadUseData: UserDataの取得に失敗しました。\(error.localizedDescription)")


### PR DESCRIPTION
Close #5 
このプルリクエストでは、Firebase Cloud Messaging (FCM) をアプリに導入し、プッシュ通知および FCM トークン管理機能を追加しました。
主な変更点として、`FirebaseMessaging` パッケージを Xcode プロジェクトに追加し、FCM トークンの取得・更新処理やサーバー同期処理を実装、さらに通知許可やトークンリフレッシュ処理をアプリライフサイクルに統合しました。これにより、アプリがプッシュ通知を受信し、FCM トークンをバックエンドと常に最新の状態に保つことが可能になります。

---

### **Firebase Messaging の統合**

* `Understand Me.xcodeproj/project.pbxproj` に `FirebaseMessaging` をパッケージ依存関係として追加し、FCM 機能を有効化するためのビルドファイルおよびプロダクト参照を設定しました。
---

### **FCM トークン管理**

* `FCMTokenManager.swift` を新規追加し、非同期での FCM トークン取得およびサーバーへの更新処理を実装しました。
  エラーハンドリングやトークン更新時の通知送信機能も含まれています。
* FCM トークン更新時に他のコンポーネントが反応できるよう、`.fcmTokenRefreshed` 通知を追加しました。

---

### **アプリライフサイクルと通知処理**

* `Understand_MeApp.swift` を更新し、通知許可リクエスト、リモート通知の登録、FCM および通知デリゲートの設定、APNs トークン登録および FCM トークン更新イベントの処理を実装しました。

---

### **ViewModel との統合**

* `MainTabViewModel.swift` を修正し、FCM トークン更新通知を監視して、トークンの変更やユーザーデータの読み込み時にサーバーへのトークン更新処理を実行するようにしました。