### PR TITLE
17 結果画面にスコアを表示する

### DIFF
--- a/Understand Me/Application/UseCases/ResultUseCase.swift
+++ b/Understand Me/Application/UseCases/ResultUseCase.swift
@@ -20,6 +20,11 @@ class ResultUseCase {
     }
     
     
+    func fetchResult(userID: String, homeworkID: String) async throws -> Result {
+        try await resultRepo.fetchResult(userID: userID, homeworkID: homeworkID)
+    }
+    
+    
     func calculateAverageResultsPerMonth(results: [Result], year: Int) -> [AverageResultPerMonth] {
         let calendar = Calendar.current
         var averageResultsPerMonth: [AverageResultPerMonth] = []

--- a/Understand Me/Domain/Repositories/ResultRepository.swift
+++ b/Understand Me/Domain/Repositories/ResultRepository.swift
@@ -9,4 +9,5 @@ import Foundation
 
 protocol ResultRepository {
     func fetchResults(userID: String, year: Int) async throws -> [Result]
+    func fetchResult(userID: String, homeworkID: String) async throws -> Result
 }

--- a/Understand Me/Infrastructure/LollipopResultRepository.swift
+++ b/Understand Me/Infrastructure/LollipopResultRepository.swift
@@ -55,4 +55,45 @@ class LollipopResultRepository: ResultRepository {
             throw error
         }
     }
+    
+    
+    
+    func fetchResult(userID: String, homeworkID: String) async throws -> Result {
+        let url = try lollipopUtility.makeURL("result/get_result_userID_homeworkID.php")
+        
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "user_id", value: userID),
+            URLQueryItem(name: "homework_id", value: homeworkID)
+        ]
+        
+        guard let finalURL = components?.url else {
+            throw LollipopError.InvalidURL
+        }
+        
+        let request = try lollipopUtility.makeRequest(url: finalURL, method: "GET")
+        
+        let (data, _) = try await URLSession.shared.data(for: request)
+        
+        let response = try lollipopUtility.decodeAPIResponse(from: data)
+        
+        guard let jsonString = response.dataString,
+              let jsonData = jsonString.data(using: .utf8) else {
+            throw URLError(.badServerResponse)
+        }
+
+        do {
+            
+            let decoder = JSONDecoder()
+            let result = try decoder.decode(Result.self, from: jsonData)
+            
+            return result
+            
+        }catch {
+            let rawString = String(data: jsonData, encoding: .utf8) ?? "nil"
+            logger.error("Decodeに失敗したDataの中身: \(rawString)")
+            logger.error("Result のDecodeに失敗しました: \(error.localizedDescription)")
+            throw error
+        }
+    }
 }

--- a/Understand Me/Infrastructure/TestRepository/TestResultRepository.swift
+++ b/Understand Me/Infrastructure/TestRepository/TestResultRepository.swift
@@ -9,6 +9,10 @@ import Foundation
 
 
 class TestResultRepository: ResultRepository {
+    func fetchResult(userID: String, homeworkID: String) async throws -> Result {
+        return .getDummy()
+    }
+    
     func fetchResults(userID: String, year: Int) async throws -> [Result] {
         return [.getDummy(), .getDummy(), .getDummy()]
     }

--- a/Understand Me/Presentation/ViewModels/HomeworkDetailViewModel.swift
+++ b/Understand Me/Presentation/ViewModels/HomeworkDetailViewModel.swift
@@ -55,24 +55,28 @@ class HomeworkDetailViewModel: ObservableObject {
     @Published var homework: HomeworkWithStatus?
     @Published var classDetail: Class?
     @Published var homeworkLinkTxt: String = ""
-    @Published var resultsPerMonth: [AverageResultPerMonth] = []
+    @Published var result: Result? = nil
     
     private let homeworkUseCase: HomeworkUseCase
     private let classUseCase: ClassUseCase
     private let projectUseCase: ProjectUseCase
     private let authenticationUseCase: AuthenticationUseCase
+    private let resultUseCase: ResultUseCase
+    
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "UnderstandMe", category: "Presentation")
     
     init(
         homeworkUseCase: HomeworkUseCase,
         classUseCase: ClassUseCase,
         projectUseCase: ProjectUseCase,
-        authenticationUseCase: AuthenticationUseCase
+        authenticationUseCase: AuthenticationUseCase,
+        resultUseCase: ResultUseCase
     ) {
         self.homeworkUseCase = homeworkUseCase
         self.classUseCase = classUseCase
         self.projectUseCase = projectUseCase
         self.authenticationUseCase = authenticationUseCase
+        self.resultUseCase = resultUseCase
     }
     
     
@@ -177,6 +181,23 @@ class HomeworkDetailViewModel: ObservableObject {
             logger.error("HomeworkDetailViewModel.loadClassDetail: クラス情報の取得に失敗しました。\(error.localizedDescription)")
         }
     }
+    
+    
+    @MainActor
+    func loadResult(homeworkID: String) async {
+        guard let authDataResult = await authenticationUseCase.fetchCurrentUser() else {
+            logger.error("QuestionsViewModel.loadAnswersForReview: ログイン中のUserがありません。")
+            return
+        }
+
+        do {
+            self.result = try await resultUseCase.fetchResult(userID: authDataResult.id, homeworkID: homeworkID)
+        } catch {
+            // TODO: Show error to the user
+            logger.error("QuestionsViewModel.loadResult: \(error.localizedDescription)")
+        }
+    }
+
     
 }
 

--- a/Understand Me/Presentation/Views/ViewComponents/HomeworkDetailView.swift
+++ b/Understand Me/Presentation/Views/ViewComponents/HomeworkDetailView.swift
@@ -17,9 +17,10 @@ struct HomeworkDetailView: View {
         homeworkUseCase: HomeworkUseCase = .init(homeworkRepository: LollipopHomeworkRepository()),
         classUseCase: ClassUseCase = .init(classRepository: LollipopClassRepository()),
         projectUseCase: ProjectUseCase = .init(projectRepository: LollipopProjectRepository()),
-        authenticationUseCase: AuthenticationUseCase = .init(authenticationRepository: FirebaseAuthenticationRepository())
+        authenticationUseCase: AuthenticationUseCase = .init(authenticationRepository: FirebaseAuthenticationRepository()),
+        resultUseCase: ResultUseCase = .init(resultRepo: LollipopResultRepository())
     ) {
-        self._viewModel = .init(wrappedValue: .init(homeworkUseCase: homeworkUseCase, classUseCase: classUseCase, projectUseCase: projectUseCase, authenticationUseCase: authenticationUseCase))
+        self._viewModel = .init(wrappedValue: .init(homeworkUseCase: homeworkUseCase, classUseCase: classUseCase, projectUseCase: projectUseCase, authenticationUseCase: authenticationUseCase, resultUseCase: resultUseCase))
         
         self.id = id
     }
@@ -55,6 +56,7 @@ struct HomeworkDetailView: View {
                 .navigationBarTitleDisplayMode(.inline)
                 .refreshable {
                     await viewModel.loadInfoOfHomework(homeworkID: id)
+                    await viewModel.loadResult(homeworkID: id)
                 }
             } else {
                 ProgressView()
@@ -64,6 +66,7 @@ struct HomeworkDetailView: View {
         }
         .task(id: id) {
             await viewModel.loadInfoOfHomework(homeworkID: id)
+            await viewModel.loadResult(homeworkID: id)
         }
     }
     
@@ -147,12 +150,36 @@ struct HomeworkDetailView: View {
         }
     }
     
-    
-    private func homeworkTitleDescription(homework: HomeworkWithStatus, classInfo: Class) -> some View {
+    @ViewBuilder
+    private func homeworkTitleDescription(
+        homework: HomeworkWithStatus,
+        classInfo: Class
+    ) -> some View {
         VStack(alignment: .leading) {
-            Text(homework.title)
-                .font(.title.bold())
-                .padding(.bottom, 7)
+            HStack {
+                Text(homework.title)
+                    .font(.title.bold())
+                    .padding(.bottom, 7)
+                
+                Spacer()
+                
+                if let score = viewModel.result?.score {
+                    Text("\(score)点")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(.primary)
+                        .padding()
+                        .background(
+                            Circle()
+                                .stroke(lineWidth: 4)
+                                .foregroundStyle(LinearGradient(
+                                    gradient: Gradient(colors: [.accent, .secAccent]),
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                ))
+                        )
+                        .padding(.trailing, 20)
+                }
+            }
             
             HStack {
                 Image(systemName: "graduationcap")
@@ -245,7 +272,6 @@ struct HomeworkDetailView: View {
             homeworkUseCase: HomeworkUseCase(homeworkRepository: TestHomeworkRepository()),
             classUseCase: ClassUseCase(classRepository: TestClassRepository()),
             projectUseCase: ProjectUseCase(projectRepository: TestProjectRepository()),
-            authenticationUseCase: AuthenticationUseCase(authenticationRepository: TestAuthenticationRepository())
-        )
+            authenticationUseCase: AuthenticationUseCase(authenticationRepository: TestAuthenticationRepository()), resultUseCase: ResultUseCase(resultRepo: TestResultRepository()))
     }
 }


### PR DESCRIPTION
## Close #17 

このプルリクエストでは、宿題詳細ビューで特定の宿題に対するユーザーの結果を取得して表示できる機能を追加しました。主な変更点として、単一の結果を取得する新しいメソッドの導入、ViewModelおよびビューの更新、そして結果をUIに表示する処理が含まれます。

### バックエンドおよびリポジトリの拡張
* `ResultRepository` プロトコルに `fetchResult(userID:homeworkID:)` を追加し、`LollipopResultRepository` および `TestResultRepository` の両方に実装しました。これにより、特定ユーザーの宿題結果を1件取得できるようになりました。
* プレゼンテーション層で使用するために、`ResultUseCase` に対応する `fetchResult(userID:homeworkID:)` メソッドを追加しました。

### ViewModelとUIの統合
* `HomeworkDetailViewModel` に `result` プロパティと `loadResult(homeworkID:)` メソッドを追加し、現在のユーザーおよび宿題に対応する結果を取得するようにしました。
* `HomeworkDetailView` を修正し、新しい `ResultUseCase` でViewModelを初期化。ビューの表示時およびリフレッシュ時に結果を読み込むようにしました。

### UIの改善
* 宿題タイトルセクションを更新し、ユーザーのスコア（利用可能な場合）をタイトルの横に円形のバッジとしてスタイリングして表示するようにしました。
