### PR TITLE
27 Userのデータを保存するときの処理を更新する

### DIFF
--- a/Understand Me/Application/UseCases/UserDataUseCase.swift
+++ b/Understand Me/Application/UseCases/UserDataUseCase.swift
@@ -10,10 +10,17 @@ import OSLog
 
 class UserDataUseCase {
     private let userDataRepository: UserDataRepository
+    private let fcmTokenRepository: FCMTokenRepository
+    private let deviceManager = DeviceManager.shared
+    
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "UnderstandMe", category: "UseCase")
     
-    init(userDataRepository: UserDataRepository) {
+    init(
+        userDataRepository: UserDataRepository,
+        fcmTokenRepository: FCMTokenRepository
+    ) {
         self.userDataRepository = userDataRepository
+        self.fcmTokenRepository = fcmTokenRepository
     }
     
     
@@ -39,6 +46,9 @@ class UserDataUseCase {
     
     
     func updateFCMToken(userID: String, fcmToken: String) async throws {
-        try await userDataRepository.updateFCMToken(userID: userID, fcmToken: fcmToken)
+        let deviceID = deviceManager.getDeviceID()
+        let deviceType = deviceManager.getDeviceType()
+        
+        try await fcmTokenRepository.saveOrUpdateToken(userID: userID, deviceID: deviceID, deviceType: deviceType, fcmToken: fcmToken)
     }
 }

--- a/Understand Me/Domain/Repositories/FCMTokenRepository.swift
+++ b/Understand Me/Domain/Repositories/FCMTokenRepository.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol FCMTokenRepository {
-    func saveOrUpdateToken(userID: String, deviceID: String, fcmToken: String) async throws
+    func saveOrUpdateToken(userID: String, deviceID: String, deviceType: String, fcmToken: String) async throws
 }

--- a/Understand Me/Domain/Repositories/FCMTokenRepository.swift
+++ b/Understand Me/Domain/Repositories/FCMTokenRepository.swift
@@ -1,0 +1,12 @@
+//
+//  FCMTokenRepository.swift
+//  Understand Me
+//
+//  Created by cmStudent on 2025/11/01.
+//
+
+import Foundation
+
+protocol FCMTokenRepository {
+    func saveOrUpdateToken(userID: String, deviceID: String, fcmToken: String) async throws
+}

--- a/Understand Me/Domain/Repositories/UserDataRepository.swift
+++ b/Understand Me/Domain/Repositories/UserDataRepository.swift
@@ -10,5 +10,4 @@ import Foundation
 protocol UserDataRepository {
     func saveUserData(userData: UserData) async throws
     func fetchUserData(userID: String) async throws -> UserData
-    func updateFCMToken(userID: String, fcmToken: String) async throws
 }

--- a/Understand Me/Helper/DeviceManager.swift
+++ b/Understand Me/Helper/DeviceManager.swift
@@ -1,0 +1,44 @@
+//
+//  DeviceIDManager.swift
+//  Understand Me
+//
+//  Created by cmStudent on 2025/11/01.
+//
+
+import Foundation
+import UIKit
+
+// Userが複数端末で同じUserIDを使う場合に備えて、端末固有のIDを生成・保存・取得するクラス
+class DeviceManager {
+    static let shared = DeviceManager()
+    
+    private let deviceIDUserDefaultsKey = "DeviceIDUserDefaultsKey"
+    
+    private init() {}
+    
+    
+    func getDeviceID() -> String {
+        let existingKey = UserDefaults.standard.string(forKey: deviceIDUserDefaultsKey)
+        if let existingKey { return existingKey }
+        
+        return createNewDeviceID()
+    }
+    
+    
+    private func createNewDeviceID() -> String {
+        let newID = UUID().uuidString
+        UserDefaults.standard.set(newID, forKey: deviceIDUserDefaultsKey)
+        return newID
+    }
+}
+
+extension DeviceManager {
+
+    func getDeviceType() -> String {
+        let device = UIDevice.current.model // "iPhone", "iPad", etc.
+        let systemName = UIDevice.current.systemName // e.g., "iOS"
+        let systemVersion = UIDevice.current.systemVersion // e.g., "16.0"
+        let deviceName = UIDevice.current.name // e.g., "John's iPhone"
+        return device + "-" + systemName + "-" + systemVersion + "-" + deviceName
+    }
+}

--- a/Understand Me/Infrastructure/LollipopFCMTokenRepository.swift
+++ b/Understand Me/Infrastructure/LollipopFCMTokenRepository.swift
@@ -1,0 +1,35 @@
+//
+//  LollipopFCMTokenRepository.swift
+//  Understand Me
+//
+//  Created by cmStudent on 2025/11/01.
+//
+
+import Foundation
+import OSLog
+
+class LollipopFCMTokenRepository: FCMTokenRepository {
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "UnderstandMe", category: "Domain")
+    
+    private let lollipopUtility = LollipopAPIUtility()
+    
+    
+    func saveOrUpdateToken(userID: String, deviceID: String, fcmToken: String) async throws {
+        let url = try lollipopUtility.makeURL("user/update_fcm_token.php")
+        let body = try JSONEncoder().encode([
+            "user_id": userID,
+            "device_id": deviceID,
+            "fcm_token": fcmToken
+        ])
+        let request = try lollipopUtility.makeRequest(url: url, method: "POST", body: body)
+        
+        let (data, _) = try await URLSession.shared.data(for: request)
+        let response = try lollipopUtility.decodeAPIResponse(from: data)
+        
+        guard response.status == "success" else {
+            logger.error("ResponseのStatusがsuccessではありません。エラー詳細: \(response.message)")
+            throw LollipopError.InvalidResponseStatus
+        }
+    }
+    
+}

--- a/Understand Me/Infrastructure/LollipopFCMTokenRepository.swift
+++ b/Understand Me/Infrastructure/LollipopFCMTokenRepository.swift
@@ -14,11 +14,17 @@ class LollipopFCMTokenRepository: FCMTokenRepository {
     private let lollipopUtility = LollipopAPIUtility()
     
     
-    func saveOrUpdateToken(userID: String, deviceID: String, fcmToken: String) async throws {
+    func saveOrUpdateToken(
+        userID: String,
+        deviceID: String,
+        deviceType: String,
+        fcmToken: String
+    ) async throws {
         let url = try lollipopUtility.makeURL("user/update_fcm_token.php")
         let body = try JSONEncoder().encode([
             "user_id": userID,
             "device_id": deviceID,
+            "device_type": deviceType,
             "fcm_token": fcmToken
         ])
         let request = try lollipopUtility.makeRequest(url: url, method: "POST", body: body)

--- a/Understand Me/Infrastructure/TestRepository/TestFCMTokenRepository.swift
+++ b/Understand Me/Infrastructure/TestRepository/TestFCMTokenRepository.swift
@@ -1,0 +1,17 @@
+//
+//  TestFCMTokenRepository.swift
+//  Understand Me
+//
+//  Created by cmStudent on 2025/11/01.
+//
+
+import Foundation
+
+class TestFCMTokenRepository: FCMTokenRepository {
+    
+    
+    func saveOrUpdateToken(userID: String, deviceID: String, deviceType: String, fcmToken: String) async throws {
+        return
+    }
+
+}

--- a/Understand Me/Presentation/Views/HomeView.swift
+++ b/Understand Me/Presentation/Views/HomeView.swift
@@ -18,14 +18,15 @@ struct HomeView: View {
         authenticationRepo: AuthenticationRepository = FirebaseAuthenticationRepository(),
         userDataRepo: UserDataRepository = LollipopUserDataRepository(),
         homeworkRepo: HomeworkRepository = LollipopHomeworkRepository(),
-        classRepo: ClassRepository = LollipopClassRepository()
+        classRepo: ClassRepository = LollipopClassRepository(),
+        fcmTokenRepo: FCMTokenRepository = LollipopFCMTokenRepository()
     ) {
         self._selectedTab = selectedTab
         
         self._viewModel = .init(
             wrappedValue: .init(
                 authenticationUseCase: AuthenticationUseCase(authenticationRepository: authenticationRepo),
-                userDataUseCase: UserDataUseCase(userDataRepository: userDataRepo),
+                userDataUseCase: UserDataUseCase(userDataRepository: userDataRepo, fcmTokenRepository: fcmTokenRepo),
                 homeworkUseCase: HomeworkUseCase(homeworkRepository: homeworkRepo),
                 classWIthTeacherNameUseCase: ClassWithTeacherNameUseCase(classRepository: classRepo, userRepository: userDataRepo)
             )
@@ -187,7 +188,8 @@ struct HomeView: View {
             authenticationRepo: TestAuthenticationRepository(),
             userDataRepo: TestUserRepository(),
             homeworkRepo: TestHomeworkRepository(),
-            classRepo: TestClassRepository()
+            classRepo: TestClassRepository(),
+            fcmTokenRepo: TestFCMTokenRepository()
         )
     }
 }

--- a/Understand Me/Presentation/Views/MainTabView.swift
+++ b/Understand Me/Presentation/Views/MainTabView.swift
@@ -15,7 +15,7 @@ struct MainTabView: View {
     
     @StateObject private var viewModel = MainTabViewModel(
         userDataUseCase: UserDataUseCase(
-            userDataRepository: LollipopUserDataRepository()
+            userDataRepository: LollipopUserDataRepository(), fcmTokenRepository: LollipopFCMTokenRepository()
         )
     )
     

--- a/Understand Me/Presentation/Views/ProfileView.swift
+++ b/Understand Me/Presentation/Views/ProfileView.swift
@@ -31,7 +31,7 @@ struct ProfileView: View {
     
     init(
         authenticationUseCase: AuthenticationUseCase = AuthenticationUseCase(authenticationRepository:FirebaseAuthenticationRepository()),
-        userDataUseCase: UserDataUseCase = UserDataUseCase(userDataRepository: LollipopUserDataRepository()),
+        userDataUseCase: UserDataUseCase = UserDataUseCase(userDataRepository: LollipopUserDataRepository(), fcmTokenRepository: LollipopFCMTokenRepository()),
         resultUseCase: ResultUseCase = ResultUseCase(resultRepo: LollipopResultRepository()),
         onSignOut: @escaping () -> ()
     ) {
@@ -314,10 +314,22 @@ struct ProfileView: View {
 #Preview {
     NavigationStack {
         ProfileView(
-            authenticationUseCase: AuthenticationUseCase(authenticationRepository: TestAuthenticationRepository()),
-            userDataUseCase: UserDataUseCase(userDataRepository: TestUserRepository()),
-            resultUseCase: ResultUseCase(resultRepo: TestResultRepository())
-            ,onSignOut: {}
+            
+            authenticationUseCase:
+                AuthenticationUseCase(authenticationRepository: TestAuthenticationRepository()),
+            
+            userDataUseCase:
+                UserDataUseCase(
+                userDataRepository: TestUserRepository(),
+                fcmTokenRepository: TestFCMTokenRepository()
+            ),
+            
+            resultUseCase:
+                ResultUseCase(resultRepo: TestResultRepository())
+            ,
+            
+            onSignOut: {
+            }
         )
     }
 }


### PR DESCRIPTION
close #24 
close #27 
 このプルリクエストは、FCMトークン管理を専用リポジトリ実装に分離し、端末識別や依存注入も改良した大規模リファクタです。

### 主な変更点
- `FCMTokenRepository`プロトコル（および本番用・テスト用実装）を新規導入、FCMトークン管理ロジックを`UserDataRepository`から独立させて専用のサービス化。
- `UserDataUseCase`は両リポジトリを依存として持ち、FCMトークン更新は`DeviceManager`経由でデバイスID・タイプを含めて処理するよう変更。
- `UserDataRepository`からFCMトークン更新メソッドを除去し、責務分離を明確化した。

### DI（依存注入）関連の修正
- `HomeView`、`MainTabView`、`ProfileView`コンストラクターやプレビューを新リポジトリに対応させ、全アプリ／テストで一貫したFCMトークン運用を実現。
### FCMトークン管理のベストプラクティス
- トークンはデバイスごとに保存・管理し、ユーザーが複数端末を持つ場合もしっかり識別できる仕組みが推奨されています。
- 定期的なトークン更新（例えば月1回）で無効化・失効への対応や情報の新鮮さを保つことが重要です。

これにより、端末単位での通知管理の拡張性や安全性が強化されています。